### PR TITLE
Run build from a clean checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ brew update
 brew install node
 brew cask install java
 brew cask install calibre
+npm install -g gitbook-cli
 ```
 
 ### Usage

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ node {
 
 
 task generateBook(type: GenerateBook){
+    dependsOn gradle.includedBuild('gradeladder-generator').task(':build')
     inputFile = project.file('input/expectations.csv')
     outputDirectory = project.file('src')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,6 @@
+import com.capgemini.javaengineering.gradeladder.BuildGitBook
+import com.capgemini.javaengineering.gradeladder.GenerateBook
+
 plugins {
     id "com.moowork.node" version "0.8"
 }
@@ -26,32 +29,27 @@ node {
 }
 
 
-task buildPdf(type: Exec, dependsOn: ['generateBook', 'npmInstall']) {
-    executable = 'gitbook'
-    args = ['pdf', './', "./output/capgemini_grade_ladder.pdf", "--verbose"]
+task generateBook(type: GenerateBook){
+    inputFile = project.file('input/expectations.csv')
+    outputDirectory = project.file('src')
 }
 
-task buildEpub(type: Exec, dependsOn: ['generateBook', 'npmInstall']) {
-    executable = 'gitbook'
-    args = ['epub', './', "./output/capgemini_grade_ladder.epub", "--verbose"]
+['pdf', 'epub', 'mobi'].each { bookType ->
+    tasks.create("build$bookType", BuildGitBook) { task ->
+        task.dependsOn tasks.generateBook
+        task.inputDirectory = tasks.generateBook.outputDirectory
+        task.type = bookType
+    }
 }
 
-task buildMobi(type: Exec, dependsOn: ['generateBook', 'npmInstall']) {
-    executable = 'gitbook'
-    args = ['mobi', './', "./output/capgemini_grade_ladder.mobi", "--verbose"]
-}
-
-task buildAll(dependsOn: ['buildMobi', 'buildEpub', 'buildPdf']) {
-    println 'Built PDF, Mobi and EPub!'
+task buildAll {
+    dependsOn tasks.withType(BuildGitBook)
+    doLast {
+        println 'Built PDF, Mobi and EPub!'
+    }
 }
 
 task serveBook(type:Exec, dependsOn: ['generateBook', 'npmInstall']) {
     executable = 'gitbook'
     args = ['serve', './', "./output/http", '--verbose']
-}
-
-task generateBook(type:Exec){
-    dependsOn gradle.includedBuild('gradeladder-generator').task(':build')
-    executable = 'java'
-    args = ['-jar', 'gradeladder-generator/build/libs/gradeladder-generator-1.0-SNAPSHOT.jar', './input/expectations.csv', './src']
 }

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ task generateBook(type: GenerateBook){
 }
 
 ['pdf', 'epub', 'mobi'].each { bookType ->
-    tasks.create("build$bookType", BuildGitBook) { task ->
+    tasks.create("build${bookType.capitalize()}", BuildGitBook) { task ->
         task.dependsOn tasks.generateBook
         task.inputDirectory = tasks.generateBook.outputDirectory
         task.type = bookType

--- a/buildSrc/src/main/groovy/com/capgemini/javaengineering/gradeladder/BuildGitBook.groovy
+++ b/buildSrc/src/main/groovy/com/capgemini/javaengineering/gradeladder/BuildGitBook.groovy
@@ -1,0 +1,35 @@
+package com.capgemini.javaengineering.gradeladder
+
+import org.gradle.api.tasks.Exec
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.ParallelizableTask
+import org.gradle.api.tasks.TaskAction
+
+@ParallelizableTask
+class BuildGitBook extends Exec {
+
+    @InputDirectory
+    File inputDirectory
+
+    @OutputDirectory
+    File outputDirectory
+
+    String type
+
+    BuildGitBook() {
+        this.executable = 'gitbook'
+    }
+
+    @TaskAction
+    void doBuild() {
+        this.args = [type, "$inputDirectory.parent", "$outputDirectory.absolutePath/capgemini_grade_ladder.$type", "--verbose"]
+        super.exec()
+    }
+
+    void setType(String type) {
+        this.type = type
+        this.outputDirectory = project.file("${project.buildDir}/output/$type")
+    }
+
+}

--- a/buildSrc/src/main/groovy/com/capgemini/javaengineering/gradeladder/GenerateBook.groovy
+++ b/buildSrc/src/main/groovy/com/capgemini/javaengineering/gradeladder/GenerateBook.groovy
@@ -1,0 +1,27 @@
+package com.capgemini.javaengineering.gradeladder
+
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.JavaExec
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+
+class GenerateBook extends JavaExec {
+
+    @InputFile
+    File inputFile
+
+    @OutputDirectory
+    File outputDirectory
+
+    GenerateBook() {
+        this.main = "com.capgemini.javaengineering.gradeladder.GradeLadderGeneratorApp"
+        this.classpath = project.files(['gradeladder-generator/build/libs/gradeladder-generator-1.0-SNAPSHOT.jar'])
+    }
+
+    @TaskAction
+    void doGenerate() {
+        this.args = ["$inputFile.absolutePath", "$outputDirectory.absolutePath"]
+        super.exec()
+    }
+
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+org.gradle.parallel=true
+org.gradle.jvmargs=-Dorg.gradle.parallel.intra=true


### PR DESCRIPTION
I had issues running this build from a clean checkout of the source.  I had to install `gitbook-cli` and create an `output` folder.

Creating the `output` folder led me to properly define the inputs and outputs of the tasks instead.  Now the folder is automatically created by Gradle in the build directory and deleted when you run `clean`.  

Well defined inputs and outputs also has the benefit of incremental compilation.  You can see this in action if you run `buildPdf` and then `buildAll` for example.  Because `buildPdf` has already been run it will show as `UP-TO-DATE` and not run again.  The same goes for `generateBook`, it will now only run if the input file has changed.

I also configured the tasks so they can be run in parallel and reduces the full build time from ~19s to ~9s.  This does mean the generated output needs to in different folders by type.

Feel free to take what you want from the PR, or none of it at all :)